### PR TITLE
Add typing middleware for Telegram bot

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -10,6 +10,7 @@ from handlers import (
 import asyncio
 import logging
 from utils.commands import set_commands
+from middlewares.typing import TypingMiddleware
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,8 @@ async def start():
 
     dp.startup.register(start_bot)
     dp.shutdown.register(stop_bot)
+
+    dp.message.middleware.register(TypingMiddleware())
 
     dp.include_routers(
         speech.router,

--- a/bot/middlewares/__init__.py
+++ b/bot/middlewares/__init__.py
@@ -1,0 +1,1 @@
+from .typing import TypingMiddleware

--- a/bot/middlewares/typing.py
+++ b/bot/middlewares/typing.py
@@ -1,0 +1,38 @@
+import asyncio
+from typing import Any, Callable, Awaitable
+
+from aiogram import BaseMiddleware
+from aiogram.types import Message
+
+
+class TypingMiddleware(BaseMiddleware):
+    """Send 'typing' action while handler is processing."""
+
+    def __init__(self, interval: float = 4.0):
+        self.interval = interval
+
+    async def __call__(
+        self,
+        handler: Callable[[Message, dict[str, Any]], Awaitable[Any]],
+        event: Message,
+        data: dict[str, Any],
+    ) -> Any:
+        if not isinstance(event, Message):
+            return await handler(event, data)
+
+        stop_event = asyncio.Event()
+
+        async def send_typing() -> None:
+            while not stop_event.is_set():
+                try:
+                    await event.bot.send_chat_action(event.chat.id, "typing")
+                    await asyncio.wait_for(stop_event.wait(), timeout=self.interval)
+                except asyncio.TimeoutError:
+                    continue
+
+        task = asyncio.create_task(send_typing())
+        try:
+            return await handler(event, data)
+        finally:
+            stop_event.set()
+            await task


### PR DESCRIPTION
## Summary
- add `TypingMiddleware` that repeatedly sends `typing` action during handler execution
- register the middleware in the bot dispatcher

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a59bbfc88328b68e57536e03f256